### PR TITLE
feat: add OS to actions (Stream Deck 6.6)

### DIFF
--- a/src/streamdeck/plugins/manifest.ts
+++ b/src/streamdeck/plugins/manifest.ts
@@ -1,14 +1,34 @@
+import type { ElementOf } from "../../utils";
 import { DeviceType } from "./device-type";
 
 /**
  * Defines the plugin and available actions, and all information associated with them, including the plugin's entry point, all iconography, action default behavior, etc.
  */
-export type Manifest = Manifest_6_4;
+export type Manifest = Manifest_6_4 | Manifest_6_6;
 
 /**
  * @inheritdoc
  */
 export type Manifest_6_4 = ManifestBase<"6.4" | "6.5">;
+
+/**
+ * @inheritdoc
+ */
+export type Manifest_6_6 = Omit<ManifestBase<"6.6">, "Actions"> & {
+	/**
+	 * Collection of actions provided by the plugin, and all of their information; this can include actions that are available to user's via the actions list, and actions that are
+	 * hidden to the user but available to pre-defined profiles distributed with the plugin (`Manifest.Actions.VisibleInActionsList`).
+	 */
+	Actions: (ElementOf<Manifest_6_4["Actions"]> & {
+		/**
+		 * Operating system that the action supports.
+		 * @minItems 1
+		 * @maxItems 2
+		 * @uniqueItems
+		 */
+		OS?: OS["Platform"][];
+	})[];
+};
 
 /**
  * Defines the plugin and available actions, and all information associated with them, including the plugin's entry point, all iconography, action default behavior, etc.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,4 @@
+/**
+ * Gets the element type of the {@template ArrayType}.
+ */
+export type ElementOf<ArrayType extends readonly unknown[]> = ArrayType extends readonly (infer ElementType)[] ? ElementType : never;


### PR DESCRIPTION
- Add `Actions[].OS` to Stream Deck 6.6 manifest.