### PR TITLE
fix: custom keywords on complex types

### DIFF
--- a/src/streamdeck/plugins/manifest/__tests__/all.test.ts
+++ b/src/streamdeck/plugins/manifest/__tests__/all.test.ts
@@ -1,0 +1,282 @@
+import { validateStreamDeckPluginManifest } from "@tests";
+
+describe.each(["v6.4", "v6.5", "v6.6"])("%s", (version) => {
+	const filePath = `${version}.json`;
+
+	/**
+	 * Asserts the patterns of `Actions[]`.
+	 */
+	describe("Actions[]", () => {
+		/**
+		 * Asserts the pattern of `Icon`.
+		 */
+		test("Icon", () => {
+			// Arrange, act, assert.
+			const errors = validateStreamDeckPluginManifest(filePath, (m) => (m.Actions[0].Icon = "test.png"));
+			expect(errors).toHaveError({
+				instancePath: "/Actions/0/Icon",
+				keyword: "pattern",
+				pattern: patterns.IMAGE_PATH
+			});
+		});
+
+		/**
+		 * Asserts the pattern of `PropertyInspectorPath`.
+		 */
+		test("PropertyInspectorPath", () => {
+			// Arrange, act.
+			const errors = validateStreamDeckPluginManifest(filePath, (m) => {
+				// @ts-expect-error Test non-HTML file path.
+				m.Actions[0].PropertyInspectorPath = "file.txt";
+			});
+
+			// Assert.
+			expect(errors).toHaveError({
+				instancePath: "/Actions/0/PropertyInspectorPath",
+				keyword: "pattern",
+				pattern: patterns.HTML_PATH
+			});
+		});
+
+		/**
+		 * Asserts the pattern of `UUID`.
+		 */
+		test("UUID", () => {
+			// Arrange, act, assert.
+			const errors = validateStreamDeckPluginManifest(filePath, (m) => (m.Actions[0].UUID = "com.$.test"));
+			expect(errors).toHaveError({
+				instancePath: "/Actions/0/UUID",
+				keyword: "pattern",
+				pattern: patterns.UUID
+			});
+		});
+
+		/**
+		 * Asserts the patterns of `Encoder`.
+		 */
+		describe("Encoder", () => {
+			/**
+			 * Asserts the pattern of `Icon`.
+			 */
+			test("Icon", () => {
+				// Arrange, act, assert.
+				const errors = validateStreamDeckPluginManifest(filePath, (m) => (m.Actions[0].Encoder!.Icon = "test.png"));
+				expect(errors).toHaveError({
+					instancePath: "/Actions/0/Encoder/Icon",
+					keyword: "pattern",
+					pattern: patterns.IMAGE_PATH
+				});
+			});
+
+			/**
+			 * Asserts the pattern of `StackColor`.
+			 */
+			test("StackColor", () => {
+				// Arrange, act, assert.
+				const errors = validateStreamDeckPluginManifest(filePath, (m) => (m.Actions[0].Encoder!.StackColor = "other.png"));
+				expect(errors).toHaveError({
+					instancePath: "/Actions/0/Encoder/StackColor",
+					keyword: "pattern",
+					pattern: patterns.COLOR
+				});
+			});
+
+			/**
+			 * Asserts the pattern of `background`.
+			 */
+			test("background", () => {
+				// Arrange, act, assert.
+				const errors = validateStreamDeckPluginManifest(filePath, (m) => (m.Actions[0].Encoder!.background = "test.png"));
+				expect(errors).toHaveError({
+					instancePath: "/Actions/0/Encoder/background",
+					keyword: "pattern",
+					pattern: patterns.ENCODER_BACKGROUND_PATH
+				});
+			});
+
+			/**
+			 * Asserts the pattern of `layout`.
+			 */
+			test("layout", () => {
+				// Arrange, act, assert.
+				const errors = validateStreamDeckPluginManifest(filePath, (m) => (m.Actions[0].Encoder!.layout = "./test.json"));
+				expect(errors).toHaveError({
+					instancePath: "/Actions/0/Encoder/layout",
+					keyword: "pattern",
+					pattern: patterns.LAYOUT
+				});
+			});
+		});
+
+		/**
+		 * Asserts the patterns of `States[]`.
+		 */
+		describe("States[]", () => {
+			/**
+			 * Asserts the pattern of `Image`.
+			 */
+			test("Image", () => {
+				// Arrange, act, assert.
+				const errors = validateStreamDeckPluginManifest(filePath, (m) => (m.Actions[0].States[0].Image = "test.png"));
+				expect(errors).toHaveError({
+					instancePath: "/Actions/0/States/0/Image",
+					keyword: "pattern",
+					pattern: patterns.IMAGE_PATH_WITH_GIF_SUPPORT
+				});
+			});
+
+			/**
+			 * Asserts the pattern of `MultiActionImage`.
+			 */
+			test("MultiActionImage", () => {
+				// Arrange, act, assert.
+				const errors = validateStreamDeckPluginManifest(filePath, (m) => (m.Actions[0].States[0].MultiActionImage = "test.png"));
+				expect(errors).toHaveError({
+					instancePath: "/Actions/0/States/0/MultiActionImage",
+					keyword: "pattern",
+					pattern: patterns.IMAGE_PATH
+				});
+			});
+
+			/**
+			 * Asserts the pattern of `TitleColor`.
+			 */
+			test("TitleColor", () => {
+				// Arrange, act, assert.
+				const errors = validateStreamDeckPluginManifest(filePath, (m) => (m.Actions[0].States[0].TitleColor = "other"));
+				expect(errors).toHaveError({
+					instancePath: "/Actions/0/States/0/TitleColor",
+					keyword: "pattern",
+					pattern: patterns.COLOR
+				});
+			});
+		});
+	});
+
+	/**
+	 * Asserts the pattern of `CategoryIcon`.
+	 */
+	test("CategoryIcon", () => {
+		// Arrange, act, assert.
+		const errors = validateStreamDeckPluginManifest(filePath, (m) => (m.CategoryIcon = "test.png"));
+		expect(errors).toHaveError({
+			instancePath: "/CategoryIcon",
+			keyword: "pattern",
+			pattern: patterns.IMAGE_PATH
+		});
+	});
+
+	/**
+	 * Asserts the pattern of `CodePath`.
+	 */
+	test("CodePath", () => {
+		// Arrange, act, assert.
+		const errors = validateStreamDeckPluginManifest(filePath, (m) => (m.CodePath = "./file.exe"));
+		expect(errors).toHaveError({
+			instancePath: "/CodePath",
+			keyword: "pattern",
+			pattern: patterns.FILE_PATH
+		});
+	});
+
+	/**
+	 * Asserts the pattern of `CodePathMac`.
+	 */
+	test("CodePathMac", () => {
+		// Arrange, act, assert.
+		const errors = validateStreamDeckPluginManifest(filePath, (m) => (m.CodePathMac = "./file.exe"));
+		expect(errors).toHaveError({
+			instancePath: "/CodePathMac",
+			keyword: "pattern",
+			pattern: patterns.FILE_PATH
+		});
+	});
+
+	/**
+	 * Asserts the pattern of `CodePathWin`.
+	 */
+	test("CodePathWin", () => {
+		// Arrange, act, assert.
+		const errors = validateStreamDeckPluginManifest(filePath, (m) => (m.CodePathWin = "./file.exe"));
+		expect(errors).toHaveError({
+			instancePath: "/CodePathWin",
+			keyword: "pattern",
+			pattern: patterns.FILE_PATH
+		});
+	});
+
+	/**
+	 * Asserts the pattern of `Icon`.
+	 */
+	test("Icon", () => {
+		// Arrange, act, assert.
+		const errors = validateStreamDeckPluginManifest(filePath, (m) => (m.Icon = "test.png"));
+		expect(errors).toHaveError({
+			instancePath: "/Icon",
+			keyword: "pattern",
+			pattern: patterns.IMAGE_PATH
+		});
+	});
+
+	/**
+	 * Asserts the patterns of `Profiles[]`.
+	 */
+	describe("Profiles[]", () => {
+		test("Name", () => {
+			// Arrange, act.
+			const errors = validateStreamDeckPluginManifest(filePath, (m) => {
+				m.Profiles![0].Name = "other.streamDeckProfile";
+			});
+
+			// Assert.
+			expect(errors).toHaveError({
+				instancePath: "/Profiles/0/Name",
+				keyword: "pattern",
+				pattern: patterns.PROFILE_PATH
+			});
+		});
+	});
+
+	/**
+	 * Asserts the pattern of `PropertyInspectorPath`.
+	 */
+	test("PropertyInspectorPath", () => {
+		// Arrange, act.
+		const errors = validateStreamDeckPluginManifest(filePath, (m) => {
+			// @ts-expect-error Test non-HTML file path string.
+			m.PropertyInspectorPath = "test.txt";
+		});
+
+		// Assert.
+		expect(errors).toHaveError({
+			instancePath: "/PropertyInspectorPath",
+			keyword: "pattern",
+			pattern: patterns.HTML_PATH
+		});
+	});
+
+	/**
+	 * Asserts the pattern of `UUID`.
+	 */
+	test("UUID", () => {
+		// Arrange, act, assert.
+		const errors = validateStreamDeckPluginManifest(filePath, (m) => (m.UUID = "com.$.test"));
+		expect(errors).toHaveError({
+			instancePath: "/UUID",
+			keyword: "pattern",
+			pattern: patterns.UUID
+		});
+	});
+});
+
+const patterns = {
+	COLOR: "^#(?:[0-9a-fA-F]{3}){1,2}$",
+	ENCODER_BACKGROUND_PATH: "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Pp][Nn][Gg])|([Ss][Vv][Gg]))$).*$",
+	FILE_PATH: "^(?![~\\.]*[\\\\\\/]+).*$",
+	HTML_PATH: "^(?![~\\.]*[\\\\\\/]+).*\\.(([Hh][Tt][Mm])|([Hh][Tt][Mm][Ll]))$",
+	LAYOUT: "^(^(?![\\.]*[\\\\\\/]+).+\\.([Jj][Ss][Oo][Nn])$)|(\\$(X1|A0|A1|B1|B2|C1))$",
+	IMAGE_PATH_WITH_GIF_SUPPORT: "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Gg][Ii][Ff])|([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
+	IMAGE_PATH: "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Vv][Gg])|([Pp][Nn][Gg]))$).*$",
+	PROFILE_PATH: "^(?![~\\.]*[\\\\\\/]+)(?!.*\\.(([Ss][Tt][Rr][Ee][Aa][Mm][Dd][Ee][Cc][Kk][Pp][Rr][Oo][Ff][Ii][Ll][Ee]))$).*$",
+	UUID: "^([a-z0-9-]+)(\\.[a-z0-9-]+)+$"
+};

--- a/src/streamdeck/plugins/manifest/__tests__/all.test.ts
+++ b/src/streamdeck/plugins/manifest/__tests__/all.test.ts
@@ -69,19 +69,6 @@ describe.each(["v6.4", "v6.5", "v6.6"])("%s", (version) => {
 			});
 
 			/**
-			 * Asserts the pattern of `StackColor`.
-			 */
-			test("StackColor", () => {
-				// Arrange, act, assert.
-				const errors = validateStreamDeckPluginManifest(filePath, (m) => (m.Actions[0].Encoder!.StackColor = "other.png"));
-				expect(errors).toHaveError({
-					instancePath: "/Actions/0/Encoder/StackColor",
-					keyword: "pattern",
-					pattern: patterns.COLOR
-				});
-			});
-
-			/**
 			 * Asserts the pattern of `background`.
 			 */
 			test("background", () => {
@@ -135,19 +122,6 @@ describe.each(["v6.4", "v6.5", "v6.6"])("%s", (version) => {
 					instancePath: "/Actions/0/States/0/MultiActionImage",
 					keyword: "pattern",
 					pattern: patterns.IMAGE_PATH
-				});
-			});
-
-			/**
-			 * Asserts the pattern of `TitleColor`.
-			 */
-			test("TitleColor", () => {
-				// Arrange, act, assert.
-				const errors = validateStreamDeckPluginManifest(filePath, (m) => (m.Actions[0].States[0].TitleColor = "other"));
-				expect(errors).toHaveError({
-					instancePath: "/Actions/0/States/0/TitleColor",
-					keyword: "pattern",
-					pattern: patterns.COLOR
 				});
 			});
 		});

--- a/src/streamdeck/plugins/manifest/__tests__/v6.6.test.ts
+++ b/src/streamdeck/plugins/manifest/__tests__/v6.6.test.ts
@@ -15,7 +15,7 @@ describe("v6.6", () => {
 	/**
 	 * Asserts more than 2 states are allowed.
 	 */
-	test("allow more than 2 states", () => {
+	test("Actions[].States[] allow more than 2 items", () => {
 		// Arrange, act, assert.
 		const errors = validateStreamDeckPluginManifest("v6.6.json", (m) => {
 			m.Actions[0].States.push({ Image: "imgs/two" });

--- a/src/streamdeck/plugins/manifest/latest.ts
+++ b/src/streamdeck/plugins/manifest/latest.ts
@@ -52,10 +52,12 @@ export type Manifest = {
 	 * **Examples**:
 	 * - assets/category-icon
 	 * - imgs/category
+	 * @filePath
+	 * { extensions: [".svg", ".png"], includeExtension: false }
 	 * @imageDimensions
 	 * [28, 28]
 	 */
-	CategoryIcon?: ImageFilePath;
+	CategoryIcon?: string;
 
 	/**
 	 * Path to the plugin's main entry point; this is executed when the Stream Deck application starts the plugin.
@@ -109,10 +111,12 @@ export type Manifest = {
 	 * **Examples**:
 	 * assets/plugin-icon
 	 * imgs/plugin
+	 * @filePath
+	 * { extensions: [".svg", ".png"], includeExtension: false }
 	 * @imageDimensions
 	 * [288, 288]
 	 */
-	Icon: ImageFilePath;
+	Icon: string;
 
 	/**
 	 * Name of the plugin, e.g. "Wave Link", "Camera Hub", "Control Center", etc.
@@ -157,8 +161,10 @@ export type Manifest = {
 	 *
 	 * **Also see:**
 	 * - `streamDeck.ui.onSendToPlugin(...)`
+	 * @filePath
+	 * { extensions: [".htm", ".html"], includeExtension: true }
 	 */
-	PropertyInspectorPath?: HtmlFilePath;
+	PropertyInspectorPath?: FilePath<"htm" | "html">;
 
 	/**
 	 * Preferred SDK version; this should _currently_ always be 2.
@@ -191,8 +197,12 @@ export type Manifest = {
 	 * - com.elgato.wavelink
 	 * - com.elgato.discord
 	 * - tv.twitch
+	 * @pattern
+	 * ^([a-z0-9-]+)(\.[a-z0-9-]+)+$
+	 * @errorMessage
+	 * String must be in reverse DNS format, and must only contain lowercase alphanumeric characters (a-z, 0-9), hyphens (-), and periods (.)
 	 */
-	UUID: Identifier;
+	UUID: string;
 
 	/**
 	 * Version of the plugin represented as a semantic version (https://semver.org) with a build number; pre-release identifiers are not permitted.
@@ -258,10 +268,12 @@ export type Action = {
 	 * **Examples:**
 	 * - assets/counter
 	 * - imgs/actions/mute
+	 * @filePath
+	 * { extensions: [".svg", ".png"], includeExtension: false }
 	 * @imageDimensions
 	 * [20, 20]
 	 */
-	Icon: ImageFilePath;
+	Icon: string;
 
 	/**
 	 * Name of the action; this is displayed to the user in the actions list, and is used throughout the Stream Deck application to visually identify the action.
@@ -285,8 +297,10 @@ export type Action = {
 	 * **Examples:**
 	 * - mute.html
 	 * - actions/join-voice-chat/settings.html
+	 * @filePath
+	 * { extensions: [".htm", ".html"], includeExtension: true }
 	 */
-	PropertyInspectorPath?: HtmlFilePath;
+	PropertyInspectorPath?: FilePath<"htm" | "html">;
 
 	/**
 	 * States the action can be in. When two states are defined the action will act as a toggle, with users being able to select their preferred iconography for each state.
@@ -322,8 +336,12 @@ export type Action = {
 	 * - com.elgato.wavelink.toggle-mute
 	 * - com.elgato.discord.join-voice
 	 * - tv.twitch.go-live
+	 * @pattern
+	 * ^([a-z0-9-]+)(\.[a-z0-9-]+)+$
+	 * @errorMessage
+	 * String must be in reverse DNS format, and must only contain lowercase alphanumeric characters (a-z, 0-9), hyphens (-), and periods (.)
 	 */
-	UUID: Identifier;
+	UUID: string;
 
 	/**
 	 * Determines whether the title field is available to the user when viewing the action's property inspector. Setting this to `false` will disable the user from specifying a
@@ -374,10 +392,12 @@ export type Encoder = {
 	 * **Examples:**
 	 * - assets/actions/mute/encoder-icon
 	 * - imgs/join-voice-chat-encoder
+	 * @filePath
+	 * { extensions: [".svg", ".png"], includeExtension: false }
 	 * @imageDimensions
 	 * [72, 72]
 	 */
-	Icon?: ImageFilePath;
+	Icon?: string;
 
 	/**
 	 * Background color to display in the Stream Deck application when the action is part of a dial stack, and is the current action. Represented as a hexadecimal value.
@@ -386,8 +406,10 @@ export type Encoder = {
 	 * - #d60270
 	 * - #1f1f1
 	 * - #0038a8
+	 * @pattern
+	 * ^#(?:[0-9a-fA-F]{3}){1,2}$
 	 */
-	StackColor?: HexColorString;
+	StackColor?: string;
 
 	/**
 	 * Descriptions that define the interaction of the action when it is associated with a dial / touchscreen on the Stream Deck +. This information is shown to the user.
@@ -544,10 +566,12 @@ export type State = {
 	 * **Examples:**
 	 * - assets/counter-key
 	 * - assets/icons/mute
+	 * @filePath
+	 * { extensions: [".svg", ".png"], includeExtension: false }
 	 * @imageDimensions
 	 * [72, 72]
 	 */
-	MultiActionImage?: ImageFilePath;
+	MultiActionImage?: string;
 
 	/**
 	 * Name of the state; when multiple states are defined this value is shown to the user when the action is being added to a multi-action. The user is then able to specify which
@@ -583,8 +607,10 @@ export type State = {
 	 * - #5bcefa
 	 * - #f5a9b8
 	 * - #FFFFFF
+	 * @pattern
+	 * ^#(?:[0-9a-fA-F]{3}){1,2}$
 	 */
-	TitleColor?: HexColorString;
+	TitleColor?: string;
 };
 
 /**
@@ -688,35 +714,3 @@ export type OS = {
  * File path, relative to the manifest's location.
  */
 type FilePath<TExt extends string> = `${string}.${Lowercase<TExt>}`;
-
-/**
- * Color represents as a hexadecimal string.
- * @pattern
- * ^#(?:[0-9a-fA-F]{3}){1,2}$
- * @errorMessage
- * String must be hexadecimal color.
- */
-type HexColorString = string;
-
-/**
- * File path that represents an HTML file relative to the plugin's manifest.
- * @filePath
- * { extensions: [".htm", ".html"], includeExtension: true }
- */
-type HtmlFilePath = FilePath<"htm" | "html">;
-
-/**
- * Unique identifier, in reverse DNS format.
- * @pattern
- * ^([a-z0-9-]+)(\.[a-z0-9-]+)+$
- * @errorMessage
- * String must be in reverse DNS format, and must only contain lowercase alphanumeric characters (a-z, 0-9), hyphens (-), and periods (.)
- */
-type Identifier = string;
-
-/**
- * File path that represents a file relative to the plugin's manifest, with the extension omitted. When multiple images with the same name are found, they are resolved in order.
- * @filePath
- * { extensions: [".svg", ".png"], includeExtension: false }
- */
-type ImageFilePath = string;

--- a/src/streamdeck/plugins/manifest/latest.ts
+++ b/src/streamdeck/plugins/manifest/latest.ts
@@ -406,8 +406,6 @@ export type Encoder = {
 	 * - #d60270
 	 * - #1f1f1
 	 * - #0038a8
-	 * @pattern
-	 * ^#(?:[0-9a-fA-F]{3}){1,2}$
 	 */
 	StackColor?: string;
 
@@ -607,8 +605,6 @@ export type State = {
 	 * - #5bcefa
 	 * - #f5a9b8
 	 * - #FFFFFF
-	 * @pattern
-	 * ^#(?:[0-9a-fA-F]{3}){1,2}$
 	 */
 	TitleColor?: string;
 };

--- a/tests/validate.ts
+++ b/tests/validate.ts
@@ -12,7 +12,7 @@ import type { Manifest } from "../src/streamdeck/plugins";
  */
 export function validateStreamDeckPluginManifest(filename: string, modify?: (manifest: Manifest) => void): ErrorObject<string, Record<string, unknown>, unknown>[] {
 	const schema = JSON.parse(getFileContents("../streamdeck/plugins/manifest.json"));
-	const validate = new Ajv()
+	const validate = new Ajv({ allErrors: true })
 		.addKeyword(keywordDefinitions.errorMessage)
 		.addKeyword(keywordDefinitions.filePath)
 		.addKeyword(keywordDefinitions.imageDimensions)


### PR DESCRIPTION
When versioning manifests, the custom schema keywords, for example `@filePath` were not being carried forward on utility types.

- Remove utility types.
- Refactor custom keywords to reside on the property signatures.
- Improve test coverage.