### PR TITLE
feat: export JSON schemas as a pre-compiled module

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,18 @@ npm install @elgato/schemas
 Manifest JSON file responsible for defining a Stream Deck plugin.
 
 ```ts
+// TypeScript type.
 import { type Manifest } from "@elgato/schemas/streamdeck/plugins";
-import manifestSchema from "@elgato/schemas/streamdeck/plugins/manifest.json";
+```
+
+```js
+// Schema as an object.
+import manifest from "@elgato/schemas/streamdeck/plugins/json";
+```
+
+```js
+// Schema as an object, with experimental import attributes
+import manifest from "@elgato/schemas/streamdeck/plugins/manifest.json" with { type: "json" };
 ```
 
 ```
@@ -39,8 +49,18 @@ https://schemas.elgato.com/streamdeck/plugins/manifest.json
 Layout JSON file that defines the layout of an action on Stream Deck +.
 
 ```ts
+// TypeScript type.
 import { type Layout } from "@elgato/schemas/streamdeck/plugins";
-import layoutSchema from "@elgato/schemas/streamdeck/plugins/layout.json";
+```
+
+```js
+// Schema as an object.
+import layout from "@elgato/schemas/streamdeck/plugins/json";
+```
+
+```js
+// Schema as an object, with experimental import attributes
+import layout from "@elgato/schemas/streamdeck/plugins/layout.json" with { type: "json" };
 ```
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.3.4",
 			"license": "MIT",
 			"devDependencies": {
+				"@rollup/plugin-json": "^6.1.0",
 				"@rollup/plugin-node-resolve": "^15.2.2",
 				"@rollup/plugin-typescript": "^11.1.5",
 				"@swc-node/register": "^1.8.0",
@@ -1808,6 +1809,26 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/unts"
+			}
+		},
+		"node_modules/@rollup/plugin-json": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
+			"integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"rollup": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@rollup/plugin-node-resolve": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
 			"import": "./dist/streamdeck/plugins/index.mjs",
 			"types": "./dist/streamdeck/plugins/index.d.ts"
 		},
+		"./streamdeck/plugins/json": {
+			"default": "./dist/streamdeck/plugins/json.js",
+			"import": "./dist/streamdeck/plugins/json.mjs",
+			"types": "./dist/streamdeck/plugins/json.d.ts"
+		},
 		"./streamdeck/plugins/layout.json": {
 			"default": "./streamdeck/plugins/layout.json"
 		},

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
 	},
 	"homepage": "https://github.com/elgatosf/schemas#readme",
 	"devDependencies": {
+		"@rollup/plugin-json": "^6.1.0",
 		"@rollup/plugin-node-resolve": "^15.2.2",
 		"@rollup/plugin-typescript": "^11.1.5",
 		"@swc-node/register": "^1.8.0",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,3 +1,4 @@
+import json from "@rollup/plugin-json";
 import nodeResolve from "@rollup/plugin-node-resolve";
 import typescript from "@rollup/plugin-typescript";
 import { dirname, join, parse } from "node:path";
@@ -40,7 +41,8 @@ function getConfig(input: string): RollupOptions[] {
 				typescript({
 					exclude: ["scripts/**/*.ts"]
 				}),
-				nodeResolve()
+				nodeResolve(),
+				json()
 			]
 		},
 		{
@@ -51,9 +53,9 @@ function getConfig(input: string): RollupOptions[] {
 					banner
 				}
 			],
-			plugins: [dts()]
+			plugins: [json(), dts()]
 		}
 	];
 }
 
-export default [...getConfig("index.ts"), ...getConfig("streamdeck/plugins/index.ts")] satisfies RollupOptions[];
+export default [...getConfig("index.ts"), ...getConfig("streamdeck/plugins/index.ts"), ...getConfig("streamdeck/plugins/json.ts")] satisfies RollupOptions[];

--- a/src/streamdeck/plugins/json.ts
+++ b/src/streamdeck/plugins/json.ts
@@ -1,0 +1,2 @@
+export { default as layout } from "../../../streamdeck/plugins/layout.json";
+export { default as manifest } from "../../../streamdeck/plugins/manifest.json";


### PR DESCRIPTION
This supports the migration of `require` to `import` within the `@elgato/cli` tool, without the need for experimental import attributes.