### PR TITLE
fix!: package exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 
 # Change Log
 
+## 0.4.0
+
+### 🐞 Fix
+
+-   Fix package exports.
+
 ## 0.3.9
 
 ### ♻️ Changed

--- a/package.json
+++ b/package.json
@@ -2,22 +2,20 @@
 	"name": "@elgato/schemas",
 	"version": "0.3.9",
 	"description": "Collection of schemas, and TypeScript declarations, to support the creation and validation of Stream Deck SDK files",
-	"main": "./dist/index.js",
-	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
-			"default": "./dist/index.js",
 			"import": "./dist/index.mjs",
+			"require": "./dist/index.cjs",
 			"types": "./dist/index.d.ts"
 		},
 		"./streamdeck/plugins": {
-			"default": "./dist/streamdeck/plugins/index.js",
 			"import": "./dist/streamdeck/plugins/index.mjs",
+			"require": "./dist/streamdeck/plugins/index.cjs",
 			"types": "./dist/streamdeck/plugins/index.d.ts"
 		},
 		"./streamdeck/plugins/json": {
-			"default": "./dist/streamdeck/plugins/json.js",
 			"import": "./dist/streamdeck/plugins/json.mjs",
+			"require": "./dist/streamdeck/plugins/json.cjs",
 			"types": "./dist/streamdeck/plugins/json.d.ts"
 		},
 		"./streamdeck/plugins/layout.json": {

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -27,7 +27,7 @@ function getConfig(input: string): RollupOptions[] {
 			input,
 			output: [
 				{
-					file: `${pathWithoutExtension}.js`,
+					file: `${pathWithoutExtension}.cjs`,
 					format: "cjs",
 					banner
 				},


### PR DESCRIPTION
- Updates `"default"` exports to correctly reflect `"require"`.
- Updates CJS export file names to reflect `.cjs`.
- Removes `main` and `types` from `package.json` as they are unncessary when `exports` is defined.